### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/G7_Digital64/keywords.txt
+++ b/G7_Digital64/keywords.txt
@@ -5,20 +5,20 @@
 #######################################
 # Datatypes (KEYWORD1)
 #######################################
-G7_Digital64.h  KEYWORD1
-G7_Digital64  KEYWORD1
+G7_Digital64.h	KEYWORD1
+G7_Digital64	KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
-init  KEYWORD2
-setConfig   KEYWORD2
-setPolarity   KEYWORD2
-portWrite  KEYWORD2
-portRead  KEYWORD2
-pinMode  KEYWORD2
-digitalWrite  KEYWORD2
-digitalRead  KEYWORD2
+init	KEYWORD2
+setConfig	KEYWORD2
+setPolarity	KEYWORD2
+portWrite	KEYWORD2
+portRead	KEYWORD2
+pinMode	KEYWORD2
+digitalWrite	KEYWORD2
+digitalRead	KEYWORD2
 
 #######################################
 # Instances (KEYWORD2)
@@ -27,7 +27,7 @@ digitalRead  KEYWORD2
 #######################################
 # Constants (LITERAL1)
 #######################################
-DIO_A  LITERAL1
-DIO_B  LITERAL1
-DIO_C  LITERAL1
-DIO_D  LITERAL1
+DIO_A	LITERAL1
+DIO_B	LITERAL1
+DIO_C	LITERAL1
+DIO_D	LITERAL1


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords